### PR TITLE
fix: clarify reset password federated user limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Reset or set a user's password in a Microsoft AD environment
 Type: **contain** <br>
 Read only: **False**
 
-Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so Microsoft Entra ID can return "Password cannot be changed for federated users." Manage passwords for federated users through the federation provider. For more information, see https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.
+Password reset updates the user's passwordProfile property. This property cannot be used for federated users; manage those passwords through the federation provider. For more information, refer to https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.
 
 #### Action Parameters
 

--- a/README.md
+++ b/README.md
@@ -459,14 +459,10 @@ summary.total_objects_successful | numeric | | 1 |
 
 Reset or set a user's password in a Microsoft AD environment
 
-Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile
-property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so
-Microsoft Entra ID can return "Password cannot be changed for federated users." Manage passwords for federated users
-through the federation provider. For more information, see
-https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.
-
 Type: **contain** <br>
 Read only: **False**
+
+Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so Microsoft Entra ID can return "Password cannot be changed for federated users." Manage passwords for federated users through the federation provider. For more information, see https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.
 
 #### Action Parameters
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ For ongoing operations, specific actions require different privilege levels:
 - **Manage Groups**: Groups Administrator role minimum
 - **Read-only Operations**: Directory Readers role sufficient
 
+### Reset Password Limitations
+
+The **reset password** action calls the Microsoft Graph Update user API and updates the user's `passwordProfile`
+property. This property contains the new temporary password and whether the user must change the password at next
+sign-in. Microsoft documents in the Update user API request body properties that `passwordProfile` cannot be used for
+federated users. For federated users, Microsoft Entra ID can return the error "Password cannot be changed for federated
+users." Password management for federated users should be handled through the federation provider instead.
+
+For more information, see the Microsoft Graph
+[Update user API request body](https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body).
+
 ## Configuration Overview
 
 The MS Graph for Active Directory connector supports two authentication modes:
@@ -447,6 +458,12 @@ summary.total_objects_successful | numeric | | 1 |
 ## action: 'reset password'
 
 Reset or set a user's password in a Microsoft AD environment
+
+Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile
+property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so
+Microsoft Entra ID can return "Password cannot be changed for federated users." Manage passwords for federated users
+through the federation provider. For more information, see
+https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.
 
 Type: **contain** <br>
 Read only: **False**

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -30,6 +30,17 @@ For ongoing operations, specific actions require different privilege levels:
 - **Manage Groups**: Groups Administrator role minimum
 - **Read-only Operations**: Directory Readers role sufficient
 
+### Reset Password Limitations
+
+The **reset password** action calls the Microsoft Graph Update user API and updates the user's `passwordProfile`
+property. This property contains the new temporary password and whether the user must change the password at next
+sign-in. Microsoft documents in the Update user API request body properties that `passwordProfile` cannot be used for
+federated users. For federated users, Microsoft Entra ID can return the error "Password cannot be changed for federated
+users." Password management for federated users should be handled through the federation provider instead.
+
+For more information, see the Microsoft Graph
+[Update user API request body](https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body).
+
 ## Configuration Overview
 
 The MS Graph for Active Directory connector supports two authentication modes:

--- a/msadgraph.json
+++ b/msadgraph.json
@@ -587,7 +587,7 @@
         {
             "action": "reset password",
             "description": "Reset or set a user's password in a Microsoft AD environment",
-            "verbose": "Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so Microsoft Entra ID can return \"Password cannot be changed for federated users.\" Manage passwords for federated users through the federation provider. For more information, see https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.",
+            "verbose": "Password reset updates the user's passwordProfile property. This property cannot be used for federated users; manage those passwords through the federation provider. For more information, refer to https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.",
             "type": "contain",
             "identifier": "reset_password",
             "read_only": false,

--- a/msadgraph.json
+++ b/msadgraph.json
@@ -587,6 +587,7 @@
         {
             "action": "reset password",
             "description": "Reset or set a user's password in a Microsoft AD environment",
+            "verbose": "Note: The reset password action calls the Microsoft Graph Update user API and updates the user's passwordProfile property. Microsoft documents in the request body properties that passwordProfile cannot be used for federated users, so Microsoft Entra ID can return \"Password cannot be changed for federated users.\" Manage passwords for federated users through the federation provider. For more information, see https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body.",
             "type": "contain",
             "identifier": "reset_password",
             "read_only": false,

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,4 @@
 **Unreleased**
+
+* Updated reset password documentation to clarify that the action uses the Microsoft Graph Update user API to update
+  `passwordProfile`, which Microsoft documents cannot be used for federated users.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,3 @@
 **Unreleased**
 
-* Updated reset password documentation to clarify that the action uses the Microsoft Graph Update user API to update
-  `passwordProfile`, which Microsoft documents cannot be used for federated users.
+* Updated reset password documentation to clarify that the Microsoft Graph Update user API cannot use `passwordProfile` for federated users.


### PR DESCRIPTION
### Bug Fixes
- Updated reset password documentation to clarify that the action uses the Microsoft Graph Update user API to update the user's `passwordProfile`.
- Documented Microsoft’s limitation that `passwordProfile` cannot be used for federated users, which can cause Microsoft Entra ID to return `Password cannot be changed for federated users.`
- Clarified that password management for federated users should be handled through the federation provider.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Other information
This is a documentation-only change based on a SOARHELP case. The Microsoft reference used is the Update user API request body section, where the `passwordProfile` property documents the federated-user limitation:

https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0#request-body

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
